### PR TITLE
Add in Prettier support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,18 +10,15 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:node/recommended',
+    'plugin:prettier/recommended',
   ],
   parserOptions: {
     sourceType: 'module',
   },
   plugins: ['node'],
   rules: {
-    'comma-dangle': ['error', 'always-multiline'],
-    'indent': ['error', 2],
     'linebreak-style': 'error',
-    'quote-props': ['error', 'consistent-as-needed'],
     'quotes': ['error', 'single', { avoidEscape: true }],
-    'semi': 'error',
     'sort-keys': 'error',
   },
   overrides: [

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  printWidth: 120,
+  singleQuote: true,
+  trailingComma: 'es5',
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,18 +7,16 @@ module.exports = {
   extends: [
     'eslint-config-airbnb-base',
     'eslint-config-airbnb-base/rules/strict',
-    './rules/best-practices',
-    './rules/import',
-    './rules/possible-errors',
-    './rules/stylistic-issues',
-    './rules/variables',
-  ].map(require.resolve),
+    'plugin:prettier/recommended',
+    './rules/best-practices.js',
+    './rules/import.js',
+    './rules/possible-errors.js',
+    './rules/stylistic-issues.js',
+    './rules/variables.js',
+  ],
   overrides: [
     {
-      files: [
-        '**/*.config.js',
-        '**/plopfile.js',
-      ],
+      files: ['**/*.config.js', '**/plopfile.js'],
       ...nodeConfig.recommended,
       parserOptions: {
         ecmaVersion: 2015,
@@ -30,10 +28,7 @@ module.exports = {
       },
     },
     {
-      files: [
-        '**/__{mocks,tests}__/**',
-        '**/*.{mock,test}.js',
-      ],
+      files: ['**/__{mocks,tests}__/**', '**/*.{mock,test}.js'],
       ...jestConfig.recommended,
       env: {
         jest: true,

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -9,22 +9,24 @@ module.exports = {
     'import/no-deprecated': 'error',
 
     // forbid the use of extraneous packages
-    'import/no-extraneous-dependencies': ['error', {
-      devDependencies: [
-        '**/__{mocks,stories,tests}__/**',
-        '**/*.{config,mock,spec,story,test}.js',
-        '**/plopfile.js',
-      ],
-      optionalDependencies: false,
-    }],
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: ['**/__{mocks,stories,tests}__/**', '**/*.{config,mock,spec,story,test}.js', '**/plopfile.js'],
+        optionalDependencies: false,
+      },
+    ],
 
     // report namespace imports
     'import/no-namespace': 'error',
 
     // enforce a convention in module import order
-    'import/order': ['error', {
-      'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-      'newlines-between': 'never',
-    }],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        'newlines-between': 'never',
+      },
+    ],
   },
 };

--- a/lib/rules/stylistic-issues.js
+++ b/lib/rules/stylistic-issues.js
@@ -2,25 +2,13 @@
 
 module.exports = {
   rules: {
-    // enforce linebreaks after opening and before closing array brackets
-    'array-bracket-newline': ['error', { minItems: 3, multiline: true }],
-
-    // enforce line breaks after each array element
-    'array-element-newline': ['error', { minItems: 3, multiline: true }],
-
     // enforce the consistent use of either function declarations or expressions
     'func-style': 'error',
 
     // enforce position of line comments
     'line-comment-position': 'error',
 
-    // enforce newlines between operands of ternary expressions
-    'multiline-ternary': ['error', 'never'],
-
     // disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead
     'prefer-object-spread': 'error',
-
-    // require quotes around object literal property names
-    'quote-props': ['error', 'consistent-as-needed'],
   },
 };

--- a/package.json
+++ b/package.json
@@ -22,16 +22,20 @@
   "dependencies": {
     "babel-eslint": "10.0.1",
     "eslint-config-airbnb-base": "13.1.0",
+    "eslint-config-prettier": "3.3.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "22.1.2",
-    "eslint-plugin-node": "8.0.0"
+    "eslint-plugin-node": "8.0.0",
+    "eslint-plugin-prettier": "3.0.1"
   },
   "devDependencies": {
     "eslint": "^5.9.0",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "prettier": "^1.15.0"
   },
   "peerDependencies": {
-    "eslint": "^5.9.0"
+    "eslint": "^5.9.0",
+    "prettier": "^1.15.0"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -8,9 +8,7 @@ test('should not contain invalid rules', () => {
     useEslintrc: false,
   });
 
-  const report = cli.executeOnText(
-    'module.exports = {};\n',
-  );
+  const report = cli.executeOnText('module.exports = {};\n');
 
   expect(report).toBeTruthy();
   expect(report.errorCount).toBe(0);


### PR DESCRIPTION
[Prettier](https://prettier.io) alleviates the need for formatting rules in ESLint (and other linters), leaving the linters to handle code-quality rules.

Here are some links for some light reading:
- [What is Prettier?](https://prettier.io/docs/en/index.html)
- [Why Prettier?](https://prettier.io/docs/en/why-prettier.html)