### PR TITLE
Rename the `jest/no-empty-title` rule to `jest/valid-title`

### DIFF
--- a/lib/rules/jest.js
+++ b/lib/rules/jest.js
@@ -27,9 +27,6 @@ module.exports = {
         // disallow duplicate hooks within a `describe` block
         'jest/no-duplicate-hooks': 'error',
 
-        // disallow empty titles
-        'jest/no-empty-title': 'error',
-
         // disallow using `expect().resolves`
         'jest/no-expect-resolves': 'error',
 
@@ -77,6 +74,9 @@ module.exports = {
 
         // require a top-level `describe` block
         'jest/require-top-level-describe': 'error',
+
+        // enforce valid titles for jest blocks
+        'jest/valid-title': 'error',
       },
     },
   ],


### PR DESCRIPTION
In one of the updates to [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) they merged two rules together but didn't mention this in their CHANGELOG 🙈

This PR just renames the now non-existant rule to the new (and existing) rule.