### PR TITLE
Allow __mocks__ and __tests__ folders to include dev dependencies

### DIFF
--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: ['plugin:import/recommended'],
   overrides: [
     {
-      files: ['*.{config,spec,test}.js'],
+      files: ['**/__mocks__/**', '**/__tests__/**', '*.{config,spec,test}.js'],
       rules: {
         // disallow the use of extraneous packages
         'import/no-extraneous-dependencies': ['error', { devDependencies: true }],


### PR DESCRIPTION
As we now use the `__tests__` folder (and maybe `__mocks__`) we need to allow them to reference `devDependencies`.

Based on the discussion here – https://github.com/tailify/web/pull/347/files#r341546268